### PR TITLE
add raspberrypi support

### DIFF
--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -47,7 +47,7 @@ pub const HYPERVISOR_VIRTUAL_BASE_ADDRESS: usize = 0x7FC0000000;
 pub const HYPERVISOR_SERIAL_BASE_ADDRESS: usize = 0x7FD0000000;
 /// The memory size to allocate
 pub const ALLOC_SIZE: usize = 256 * 1024 * 1024; /* 256 MB */
-pub const ALLOC_SIZE_SUB: usize = 16 * 1024 * 1024; /* 16 MB */
+pub const ALLOC_SIZE_SUB: usize = 32 * 1024 * 1024; /* 32 MB */
 pub const MAX_PHYSICAL_ADDRESS: usize = (1 << (52 + 1)) - 1; /* Armv8.2-A */
 //pub const MAX_PHYSICAL_ADDRESS: usize = (1 << (48 + 1)) - 1;/* Armv8.0 */
 pub const PAGE_SHIFT: usize = 12;

--- a/src/hypervisor_bootloader/Cargo.toml
+++ b/src/hypervisor_bootloader/Cargo.toml
@@ -22,6 +22,7 @@ a64fx = ["mrs_msr_emulation"]
 advanced_memory_manager = [] # Bootloader uses stack style allocator
 tftp = []
 u_boot = []
+raspberrypi = ["u_boot"]
 
 [dependencies]
 common = { path = "../common" }

--- a/src/hypervisor_kernel/Cargo.toml
+++ b/src/hypervisor_kernel/Cargo.toml
@@ -23,6 +23,7 @@ a64fx = ["mrs_msr_emulation"]
 advanced_memory_manager = ["common/advanced_memory_manager"]
 tftp = []
 u_boot = []
+raspberrypi = ["u_boot"]
 
 [dependencies]
 common = { path = "../common" }


### PR DESCRIPTION
Add raspberry pi support

To support Raspberry Pi, we need to pass modified DTB to EL1 U-Boot.
Also, we add functionality to insert reserved section into default DTB to tell hypervisor reserved section
