### PR TITLE
Change U-Boot boot pattern

### DIFF
--- a/docs/raspberry_pi4.md
+++ b/docs/raspberry_pi4.md
@@ -1,0 +1,64 @@
+# Raspberry Pi4 Support
+MilvusVisor has support for Raspberry Pi 4 environments.
+We tested "Raspberry Pi 4 Computer Model B"
+
+## Restricts
+We currently support Only single core boot. Please add "nosmp" boot option, Otherwise Linux can boot, but MilvusVisor will not work fine.
+
+## How to build
+To enable Raspberry Pi 4 support, you need to add `u_boot` feature flag on building binaries of hypervisor and bootloader.
+
+```shell
+make custom_all FEATURES=u_boot
+```
+
+## How to boot
+### Build U-boot
+(This step assumed that your environment is Ubuntu. Otherwise, please replace the package names to suitable.)
+
+1. Install `gcc-aarch64-linux-gnu` and `libssl-dev` 
+2. Clone u-boot and move into the directory
+3. `export CROSS_COMPILE=aarch64-linux-gnu-`
+4. Set configuration for Raspberry Pi 4: `make rpi_4_defconfig`
+5. Build: `make`
+6. Copy u-boot.bin
+
+You can build in the docker with the below shell script(When run docker, don't forget bind directory to get the output binary :) )
+
+```shell
+#!/bin/sh
+apt-get update
+apt-get install -y build-essential bison flex gcc-aarch64-linux-gnu libssl-dev git make
+git clone --depth=1 https://source.denx.de/u-boot/u-boot.git
+cd u-boot
+export CROSS_COMPILE=aarch64-linux-gnu-
+make rpi_4_defconfig
+make -j`nproc`
+cp u-boot.bin /path/to/bound/
+```
+
+### Download "Raspberry Pi OS (64-bit)"
+Go to https://www.raspberrypi.com/software/operating-systems/ , find "Raspberry Pi OS (64-bit)" section, and download "Raspberry Pi OS with desktop" or "Raspberry Pi OS Lite". (We tested with "Raspberry Pi OS Lite")
+
+
+### Write image and binaries
+
+1. Write the OS image to SD: (For example: `unxz 20XX-XX-XX-raspios-version-arm64-lite.img.xz && sudo dd if=20XX-XX-XX-raspios-version-arm64-lite.img of=/dev/mmcblk0 bs=10M status=progress`)
+2. Mount SD Card: `sudo mount /dev/mmcblk0p1 /mnt`
+3. Copy u-boot.bin: `sudo cp u-boot.bin /mnt/`
+4. Copy MilvusVisor: `sudo cp -r /path/to/MlivusVisor/bin/EFI /mnt`
+5. Modify config.txt: `sudo sed -i '/arm_64bit=1/akernel=u-boot.bin' /mnt/config.txt`
+6. Modify config.txt: `sudo sed -i -e 's/console=serial0,115200 console=tty1//g' /mnt/cmdline.txt`
+7. Enable UART(Optional): `sudo sed -i '/arm_64bit=1/adtoverlay=miniuart-bt\ncore_freq=250' /mnt/config.txt && sudo sed -i -e 's/quiet/console=ttyAMA0/g' /mnt/cmdline.txt`
+8. Unmount: `sudo umount /mnt`
+
+### How to Run
+1. insert SD Card into Raspberry Pi 4
+2. Connect UART(Optional)
+3. Connect USB Power
+4. Check DTB_ADDRESS which will printed by bootloader like `DTB_ADDRESS: 0x39EF7000`
+5. Wait unti u-boot shows shell like `U-Boot>`
+6. Load kernel8.img: `fatload mmc 0:1 ${kernel_addr_r} kernel8.img`
+7. Set kernel_comp_size: `setenv kernel_comp_size ${filesize}`
+8. Set kernel_comp_addr_r: `setenv kernel_comp_addr_r 0x3800000`
+9. Boot Linux(`0x39EF7000` is DTB_ADDRESS, please change the value if different from checked value): `booti ${kernel_addr_r} - 0x39EF7000`

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -47,7 +47,6 @@ pub const HYPERVISOR_VIRTUAL_BASE_ADDRESS: usize = 0x7FC0000000;
 pub const HYPERVISOR_SERIAL_BASE_ADDRESS: usize = 0x7FD0000000;
 /// The memory size to allocate
 pub const ALLOC_SIZE: usize = 256 * 1024 * 1024; /* 256 MB */
-pub const ALLOC_SIZE_SUB: usize = 32 * 1024 * 1024; /* 32 MB */
 pub const MAX_PHYSICAL_ADDRESS: usize = (1 << (52 + 1)) - 1; /* Armv8.2-A */
 //pub const MAX_PHYSICAL_ADDRESS: usize = (1 << (48 + 1)) - 1;/* Armv8.0 */
 pub const PAGE_SHIFT: usize = 12;

--- a/src/hypervisor_bootloader/.cargo/config
+++ b/src/hypervisor_bootloader/.cargo/config
@@ -1,6 +1,5 @@
 [build]
 target = "aarch64-unknown-uefi"
-rustflags = ["-C", "target-feature=+v8.1a"]
 
 [unstable]
 build-std-features = ["compiler-builtins-mem"]

--- a/src/hypervisor_bootloader/Cargo.toml
+++ b/src/hypervisor_bootloader/Cargo.toml
@@ -22,8 +22,8 @@ mrs_msr_emulation = []
 a64fx = ["mrs_msr_emulation"]
 advanced_memory_manager = [] # Bootloader uses stack style allocator
 tftp = []
-u_boot = []
-raspberrypi = ["u_boot"]
+edit_dtb_memory = []
+u_boot = ["edit_dtb_memory"]
 
 [dependencies]
 common = { path = "../common" }

--- a/src/hypervisor_bootloader/src/smmu.rs
+++ b/src/hypervisor_bootloader/src/smmu.rs
@@ -49,7 +49,10 @@ pub fn detect_smmu(acpi_address: usize) -> Option<usize> {
             return None;
         }
     };
-    let Some(smmu_v3) = iort.get_smmu_v3_information() else { println!("SMMUv3 is not found"); return None;};
+    let Some(smmu_v3) = iort.get_smmu_v3_information() else {
+        println!("SMMUv3 is not found");
+        return None;
+    };
     let base_address = smmu_v3.base_address as usize;
     println!("SMMUv3 BaseAddress: {:#X}", base_address);
 

--- a/src/hypervisor_kernel/.cargo/config
+++ b/src/hypervisor_kernel/.cargo/config
@@ -1,6 +1,6 @@
 [build]
 target = "aarch64-unknown-none"
-rustflags = ["-C", "target-feature=+v8.1a", "-C", "link-arg=-Thypervisor_kernel/config/linkerscript.ld"]
+rustflags = ["-C", "link-arg=-Thypervisor_kernel/config/linkerscript.ld"]
 
 [unstable]
 build-std = ["core", "compiler_builtins"]

--- a/src/hypervisor_kernel/Cargo.toml
+++ b/src/hypervisor_kernel/Cargo.toml
@@ -23,8 +23,8 @@ mrs_msr_emulation = []
 a64fx = ["mrs_msr_emulation"]
 advanced_memory_manager = ["common/advanced_memory_manager"]
 tftp = []
-u_boot = []
-raspberrypi = ["u_boot"]
+edit_dtb_memory = []
+u_boot = ["edit_dtb_memory"]
 
 [dependencies]
 common = { path = "../common" }


### PR DESCRIPTION
Changed the way to boot EL1 OS with U-Boot.

Previously, we needed to prepare EL1 U-Boot to boot EL1 OS.
By this change, MilvusVisor doesn't require EL1 U-Boot anymore.