### PR TITLE
[add] spin-table support

### DIFF
--- a/src/common/src/cpu.rs
+++ b/src/common/src/cpu.rs
@@ -597,6 +597,11 @@ pub fn invalidate_data_cache(virtual_address: usize) {
 }
 
 #[inline(always)]
+pub fn clean_and_invalidate_data_cache(virtual_address: usize) {
+    unsafe { asm!("DC CIVAC, {:x}", in(reg) virtual_address) };
+}
+
+#[inline(always)]
 pub fn send_event_all() {
     unsafe { asm!("SEV") };
 }

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -100,6 +100,7 @@ pub struct SystemInformation {
         usize, /* base_address */
         usize, /* number of pages */
     ),
+    pub spin_table_info: Option<(usize /* base_address */, usize /* length */)>,
     pub memory_save_list: *mut [MemorySaveListEntry],
     pub serial_port: Option<SerialPortInfo>,
     pub ecam_info: Option<EcamInfo>,

--- a/src/hypervisor_kernel/src/main.rs
+++ b/src/hypervisor_kernel/src/main.rs
@@ -124,6 +124,10 @@ fn hypervisor_main(system_information: &mut SystemInformation) {
         );
     }
 
+    if let Some((spin_table_address, length)) = system_information.spin_table_info {
+        multi_core::setup_spin_table(spin_table_address, length);
+    }
+
     #[cfg(feature = "acpi_table_protection")]
     if let Some(rsdp_address) = unsafe { ACPI_RSDP } {
         acpi_protect::init_table_protection(rsdp_address);

--- a/src/hypervisor_kernel/src/multi_core.rs
+++ b/src/hypervisor_kernel/src/multi_core.rs
@@ -9,10 +9,12 @@
 //! MultiCore Handling Functions
 //!
 
+use crate::memory_hook::{add_memory_store_hook_handler, StoreAccessHandlerEntry, StoreHookResult};
+use crate::paging::{add_memory_access_trap, map_address};
 use crate::psci::{call_psci_function, PsciFunctionId, PsciReturnCode};
 use crate::{allocate_memory, free_memory, StoredRegisters};
 
-use common::{cpu, PAGE_SHIFT, STACK_PAGES};
+use common::{cpu, PAGE_SHIFT, PAGE_SIZE, STACK_PAGES};
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -20,7 +22,6 @@ pub static NUMBER_OF_RUNNING_AP: AtomicUsize = AtomicUsize::new(0);
 pub static STACK_TO_FREE_LATER: AtomicUsize = AtomicUsize::new(0);
 
 #[repr(C, align(16))]
-#[derive(Debug)]
 struct HypervisorRegisters {
     cnthctl_el2: u64,
     cptr_el2: u64,
@@ -92,18 +93,6 @@ pub fn setup_new_cpu(regs: &mut StoredRegisters) {
 pub fn power_off_cpu() -> i32 {
     let stack_address = (cpu::get_sp() as usize) & !((STACK_PAGES << PAGE_SHIFT) - 1);
 
-    /*
-    STACK_TO_FREE_LATER_FLAG.lock();
-    let stack_address_to_free = STACK_TO_FREE_LATER.load(Ordering::Relaxed);
-    if stack_address_to_free != 0 {
-        if let Err(err) = free_memory(stack_address_to_free, STACK_PAGES) {
-            println!("Failed to free stack: {:?}", err);
-        }
-    }
-    STACK_TO_FREE_LATER.store(stack_address, Ordering::Relaxed);
-    STACK_TO_FREE_LATER_FLAG.unlock();
-    */
-
     loop {
         let current = STACK_TO_FREE_LATER.load(Ordering::Acquire);
         if let Ok(stack_address_to_free) = STACK_TO_FREE_LATER.compare_exchange(
@@ -123,6 +112,112 @@ pub fn power_off_cpu() -> i32 {
 
     NUMBER_OF_RUNNING_AP.fetch_sub(1, Ordering::SeqCst);
     call_psci_function(PsciFunctionId::CpuOff, 0, 0, 0) as i32
+}
+
+pub fn setup_spin_table(base_address: usize, length: usize) {
+    let aligned_base_address = if base_address == 0 {
+        0
+    } else {
+        (base_address - 1) & !(PAGE_SIZE - 1)
+    };
+    let aligned_length =
+        ((length + (base_address - aligned_base_address) - 1) & !(PAGE_SIZE - 1)) + PAGE_SIZE;
+    map_address(
+        aligned_base_address,
+        aligned_base_address,
+        aligned_length,
+        true,
+        true,
+        false,
+        true,
+    )
+    .expect("Failed to map spin table");
+    add_memory_access_trap(aligned_base_address, aligned_length, true, false)
+        .expect("Failed to add trap of spin table");
+    add_memory_store_hook_handler(StoreAccessHandlerEntry::new(
+        base_address,
+        length,
+        spin_table_store_access_handler,
+    ))
+    .expect("Failed to add store access handler");
+}
+
+fn spin_table_store_access_handler(
+    accessing_memory_address: usize,
+    _stored_registers: &mut StoredRegisters,
+    _access_size: u8,
+    data: u64,
+) -> Result<StoreHookResult, ()> {
+    const SPIN_TABLE_STACK_ADDRESS_OFFSET: usize = cpu::AA64_INSTRUCTION_SIZE * 6;
+    let stack_address = (allocate_memory(STACK_PAGES, Some(STACK_PAGES))
+        .expect("Failed to allocate stack")
+        + (STACK_PAGES << PAGE_SHIFT)) as u64;
+
+    /* Write System Registers */
+    let register_buffer = unsafe {
+        &mut *((stack_address as usize - core::mem::size_of::<HypervisorRegisters>())
+            as *mut HypervisorRegisters)
+    };
+    register_buffer.cnthctl_el2 = cpu::get_cnthctl_el2();
+    register_buffer.cptr_el2 = cpu::get_cptr_el2();
+    register_buffer.ttbr0_el2 = cpu::get_ttbr0_el2();
+    register_buffer.mair_el2 = cpu::get_mair_el2();
+    register_buffer.tcr_el2 = cpu::get_tcr_el2();
+    register_buffer.vbar_el2 = cpu::get_vbar_el2();
+    register_buffer.vttbr_el2 = cpu::get_vttbr_el2();
+    register_buffer.vtcr_el2 = cpu::get_vtcr_el2();
+    register_buffer.sctlr_el2 = cpu::get_sctlr_el2();
+    register_buffer.hcr_el2 = cpu::get_hcr_el2();
+    register_buffer.el1_entry_point = data;
+    register_buffer.el1_context_id = 0;
+
+    let register_buffer_real_address = cpu::convert_virtual_address_to_physical_address_el2_read(
+        register_buffer as *const _ as usize,
+    )
+    .expect("Failed to convert virtual address to real address");
+    let spin_table_boot_real_address = cpu::convert_virtual_address_to_physical_address_el2_read(
+        spin_table_boot as *const fn() as usize,
+    )
+    .expect("Failed to convert virtual address to real address");
+    let spin_table_boot_stack_address = unsafe {
+        &*((spin_table_boot_real_address + SPIN_TABLE_STACK_ADDRESS_OFFSET) as *const AtomicUsize)
+    };
+
+    loop {
+        while spin_table_boot_stack_address.load(Ordering::Relaxed) != 0 {
+            core::hint::spin_loop();
+        }
+        if spin_table_boot_stack_address
+            .compare_exchange(
+                0,
+                register_buffer_real_address,
+                Ordering::SeqCst,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            break;
+        }
+    }
+    cpu::isb();
+    /* Flush Memory Cache */
+    for i in 0..512 {
+        cpu::clean_and_invalidate_data_cache(spin_table_boot_real_address + i);
+    }
+    for i in 0..core::mem::size_of::<HypervisorRegisters>() {
+        cpu::clean_and_invalidate_data_cache(register_buffer as *mut _ as usize + i);
+    }
+    NUMBER_OF_RUNNING_AP.fetch_add(1, Ordering::SeqCst);
+    unsafe {
+        core::ptr::write_volatile(
+            accessing_memory_address as *mut u64,
+            spin_table_boot_real_address as u64,
+        )
+    };
+    cpu::isb();
+    cpu::clean_and_invalidate_data_cache(accessing_memory_address);
+    pr_debug!("The initialization completed.");
+    Ok(StoreHookResult::Cancel)
 }
 
 /* cpu_boot must use position-relative code */
@@ -192,5 +287,35 @@ extern "C" fn cpu_boot() {
                     ",  MAX_ZCR_EL2_LEN = const cpu::MAX_ZCR_EL2_LEN,
                         A64FX = const cfg!(feature = "a64fx") as u64,
                         options(noreturn))
+    }
+}
+
+/// # ATTENTION
+/// When modified the number of instructions,
+///   adjust `SPIN_TABLE_STACK_ADDRESS_OFFSET` at spin_table_store_access_handler.
+/// # TODO
+/// Use atomic instructions(Currently "stlxr" fails to write zero).
+#[naked]
+extern "C" fn spin_table_boot() {
+    unsafe {
+        core::arch::asm!(
+            "
+.align              3
+                    adr     x1,     2f
+1:
+                    //ldaxr   x0,     [x1]
+                    ldr     x0,     [x1]
+                    cbz     x0,     1b
+                    //stlxr   w2,     xzr, [x1]
+                    str     xzr,    [x1]
+                    //cbnz    w2,     1b
+                    nop
+                    b       {CPU_BOOT}
+2:
+                    .quad   0
+            ",
+            CPU_BOOT = sym cpu_boot,
+            options(noreturn)
+        )
     }
 }

--- a/src/hypervisor_kernel/src/multi_core.rs
+++ b/src/hypervisor_kernel/src/multi_core.rs
@@ -14,113 +14,60 @@ use crate::{allocate_memory, free_memory, StoredRegisters};
 
 use common::{cpu, PAGE_SHIFT, STACK_PAGES};
 
-use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
-pub static NUMBER_OF_RUNNING_AP: AtomicU64 = AtomicU64::new(0);
+pub static NUMBER_OF_RUNNING_AP: AtomicUsize = AtomicUsize::new(0);
 pub static STACK_TO_FREE_LATER: AtomicUsize = AtomicUsize::new(0);
 
 #[repr(C, align(16))]
 #[derive(Debug)]
 struct HypervisorRegisters {
-    stack_address: u64,
     cnthctl_el2: u64,
     cptr_el2: u64,
-    hcr_el2: u64,
-    vttbr_el2: u64,
     ttbr0_el2: u64,
     mair_el2: u64,
     tcr_el2: u64,
+    vbar_el2: u64,
+    vttbr_el2: u64,
     vtcr_el2: u64,
     sctlr_el2: u64,
-    vbar_el2: u64,
+    hcr_el2: u64,
     el1_entry_point: u64,
     el1_context_id: u64,
-    complete_flag: AtomicU64,
 }
-
-static mut REGISTER_BUFFER: HypervisorRegisters = HypervisorRegisters {
-    stack_address: 0,
-    cnthctl_el2: 0,
-    cptr_el2: 0,
-    hcr_el2: 0,
-    vttbr_el2: 0,
-    ttbr0_el2: 0,
-    mair_el2: 0,
-    tcr_el2: 0,
-    vtcr_el2: 0,
-    sctlr_el2: 0,
-    vbar_el2: 0,
-    el1_entry_point: 0,
-    el1_context_id: 0,
-    complete_flag: AtomicU64::new(1),
-};
 
 pub fn setup_new_cpu(regs: &mut StoredRegisters) {
     let stack_address = (allocate_memory(STACK_PAGES, Some(STACK_PAGES))
         .expect("Failed to allocate stack")
         + (STACK_PAGES << PAGE_SHIFT)) as u64;
-    let cnthctl_el2 = cpu::get_cnthctl_el2();
-    let cptr_el2 = cpu::get_cptr_el2();
-    let hcr_el2 = cpu::get_hcr_el2();
-    let vttbr_el2 = cpu::get_vttbr_el2();
-    let ttbr0_el2 = cpu::get_ttbr0_el2();
-    let mair_el2 = cpu::get_mair_el2();
-    let tcr_el2 = cpu::get_tcr_el2();
-    let vtcr_el2 = cpu::get_vtcr_el2();
-    let sctlr_el2 = cpu::get_sctlr_el2();
-    let vbar_el2 = cpu::get_vbar_el2();
 
-    /* Aquire REGISTER_BUFFER's lock */
-    loop {
-        let mut current;
-        loop {
-            current = unsafe { REGISTER_BUFFER.complete_flag.load(Ordering::Relaxed) };
-            if current != 0 {
-                break;
-            }
-            core::hint::spin_loop();
-        }
-        if unsafe {
-            REGISTER_BUFFER
-                .complete_flag
-                .compare_exchange_weak(current, 0, Ordering::Acquire, Ordering::Relaxed)
-                .is_ok()
-        } {
-            break;
-        }
-    }
-    unsafe {
-        REGISTER_BUFFER.stack_address = stack_address;
-        REGISTER_BUFFER.cnthctl_el2 = cnthctl_el2;
-        REGISTER_BUFFER.cptr_el2 = cptr_el2;
-        REGISTER_BUFFER.hcr_el2 = hcr_el2;
-        REGISTER_BUFFER.vttbr_el2 = vttbr_el2;
-        REGISTER_BUFFER.ttbr0_el2 = ttbr0_el2;
-        REGISTER_BUFFER.mair_el2 = mair_el2;
-        REGISTER_BUFFER.tcr_el2 = tcr_el2;
-        REGISTER_BUFFER.vtcr_el2 = vtcr_el2;
-        REGISTER_BUFFER.sctlr_el2 = sctlr_el2;
-        REGISTER_BUFFER.vbar_el2 = vbar_el2;
-        REGISTER_BUFFER.el1_entry_point = regs.x2;
-        REGISTER_BUFFER.el1_context_id = regs.x3;
-    }
+    /* Write System Registers */
+    let register_buffer = unsafe {
+        &mut *((stack_address as usize - core::mem::size_of::<HypervisorRegisters>())
+            as *mut HypervisorRegisters)
+    };
+    register_buffer.cnthctl_el2 = cpu::get_cnthctl_el2();
+    register_buffer.cptr_el2 = cpu::get_cptr_el2();
+    register_buffer.ttbr0_el2 = cpu::get_ttbr0_el2();
+    register_buffer.mair_el2 = cpu::get_mair_el2();
+    register_buffer.tcr_el2 = cpu::get_tcr_el2();
+    register_buffer.vbar_el2 = cpu::get_vbar_el2();
+    register_buffer.vttbr_el2 = cpu::get_vttbr_el2();
+    register_buffer.vtcr_el2 = cpu::get_vtcr_el2();
+    register_buffer.sctlr_el2 = cpu::get_sctlr_el2();
+    register_buffer.hcr_el2 = cpu::get_hcr_el2();
+    register_buffer.el1_entry_point = regs.x2;
+    register_buffer.el1_context_id = regs.x3;
 
-    let hypervisor_registers_real_address =
-        cpu::convert_virtual_address_to_physical_address_el2_read(
-            unsafe { &REGISTER_BUFFER } as *const _ as usize
-        )
-        .expect("Failed to convert virtual address to real address");
     let cpu_boot_address_real_address =
         cpu::convert_virtual_address_to_physical_address_el2_read(cpu_boot as *const fn() as usize)
             .expect("Failed to convert virtual address to real address");
-
-    pr_debug!("{:#X?}", unsafe { &REGISTER_BUFFER });
 
     regs.x0 = call_psci_function(
         PsciFunctionId::CpuOn,
         regs.x1,
         cpu_boot_address_real_address as u64,
-        hypervisor_registers_real_address as u64,
+        register_buffer as *const _ as usize as u64,
     );
     if regs.x0 as i32 != PsciReturnCode::Success as i32 {
         if let Err(err) = free_memory(
@@ -129,7 +76,6 @@ pub fn setup_new_cpu(regs: &mut StoredRegisters) {
         ) {
             println!("Failed to free memory: {:?}", err);
         }
-        unsafe { REGISTER_BUFFER.complete_flag.store(1, Ordering::Release) };
         println!(
             "Failed to power on the cpu (MPIDR: {:#X}): {:?}",
             regs.x1,
@@ -223,30 +169,25 @@ extern "C" fn cpu_boot() {
                     ldp x7,   x8, [x0, 16 * 3]
                     ldp x9,  x10, [x0, 16 * 4]
                     ldp x11, x12, [x0, 16 * 5]
-                    ldp x13, x14, [x0, 16 * 6]
-                    mov x14, x0
-                    add x14, x14, 8 * 13
 
-                    mov sp, x1         
-                    msr cnthctl_el2, x2
-                    msr cntvoff_el2, xzr
-                    msr cptr_el2, x3
-                    msr mair_el2, x7
-                    msr tcr_el2, x8
-                    msr vtcr_el2, x9
-                    msr ttbr0_el2, x6
-                    msr hcr_el2, x4
-                    msr sctlr_el2, x10
-                    msr vbar_el2, x11
-                    msr vttbr_el2, x5
+                    mov sp, x0
+                    add sp, sp, #(16 * 6)
+                    msr cnthctl_el2,     x1
+                    msr cntvoff_el2,    xzr
+                    msr cptr_el2,        x2
+                    msr ttbr0_el2,       x3
+                    msr mair_el2,        x4
+                    msr tcr_el2,         x5
+                    msr vbar_el2,        x6
+                    msr vttbr_el2,       x7
+                    msr vtcr_el2,        x8
+                    msr sctlr_el2,       x9
+                    msr hcr_el2,        x10
+
                     mov x1, (1 << 7) |(1 << 6) | (1 << 2) | (1) // EL1h(EL1 + Use SP_EL1)
-                    msr spsr_el2, x1
-                    msr elr_el2, x12
-                    mov x0, x13
-                    dsb sy
-                    isb
-                    str x14, [x14]
-                    isb
+                    msr spsr_el2,        x1
+                    msr elr_el2,        x11
+                    mov x0, x12
                     eret
                     ",  MAX_ZCR_EL2_LEN = const cpu::MAX_ZCR_EL2_LEN,
                         A64FX = const cfg!(feature = "a64fx") as u64,


### PR DESCRIPTION
This PR includes 2 commits.

1. Change PSCI CPU_ON  to use each stack memory from using shared memory.
2. Add support of booting application processors by spin-table.

This commit is tested on FX700/Raspberry Pi 4 B.