### PR TITLE
fix serial port detection logic

### DIFF
--- a/src/hypervisor_bootloader/src/dtb.rs
+++ b/src/hypervisor_bootloader/src/dtb.rs
@@ -457,7 +457,8 @@ impl DtbNode {
         if let Some((p, _)) = s.search_pointer_to_property(PROP_STATUS, dtb)? {
             Ok(Some(Self::match_string(p, PROP_STATUS_OKAY)))
         } else {
-            Ok(None)
+            // A node is enabled if status property does not exist.
+            Ok(Some(true))
         }
     }
 


### PR DESCRIPTION
Before this PR, we assume that a serial port is disalbed if the status
propery does not exist. But according to the document, a node is enabled
if the status propery does not exist
Ref: https://elinux.org/Device_Tree_Linux#status_property
