### PR TITLE
Fix: the path of actions/upload-artifact

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: MilvusVisor
-          path: bin/
+          path: src/bin/
           compression-level: 9


### PR DESCRIPTION
This is a minor fix of the github workflow.
